### PR TITLE
Use newer version of cbjavaloader

### DIFF
--- a/box.json
+++ b/box.json
@@ -7,7 +7,7 @@
     "dependencies":{
         "coldbox":"^4.3.0",
         "workbench":"git+https://github.com/Ortus-Solutions/unified-workbench.git",
-        "cbjavaloader":"^1.3.3+25"
+        "cbjavaloader":"^2"
     },
     "devDependencies":{
         "testbox":"2.3.0+00044"


### PR DESCRIPTION
Trying to removing dependencies on different module version if not needed. Would you please accept this and publish a new version of wikitext?